### PR TITLE
Fixed interception chaining.

### DIFF
--- a/projects/InjectDLL/interception.h
+++ b/projects/InjectDLL/interception.h
@@ -3,13 +3,14 @@
 #include <string>
 
 struct intercept {
-	intercept(__int64 o, PVOID* oP, PVOID iP, std::string s);
+    intercept(__int64 o, PVOID* oP, PVOID iP, std::string s);
 
-	std::string name;
-	__int64 offset;
-	PVOID* original_pointer;
-	PVOID intercept_pointer;
-	intercept* prev;
+    std::string name;
+    __int64 offset;
+    PVOID* original_pointer;
+    PVOID intercept_pointer;
+    intercept* next;
+    intercept* prev;
 };
 
 extern intercept* last_intercept;


### PR DESCRIPTION
Adds a chain cache that holds previously attached pointers relative to the offset, we use this to chain the intercepts.

Also maybe fixed detach.