### PR TITLE
Nerfed LowerReach + add more unsafe paths + various logic fixes

### DIFF
--- a/projects/SeedGen/areas.wotw
+++ b/projects/SeedGen/areas.wotw
@@ -3946,15 +3946,14 @@ anchor LowerReach.Entry at -390, -4025:  # Behind Baur
       Bash, Grenade=1
       Launch
     gorlek, LowerReach.BearSneezed, LowerReach.BearBridgeBroken:
-      Bash  # bash the enemy into the air first, may have to use the purple one
       SentryJump=1
       Dash, DoubleJump, TripleJump  # you only get one shot at these else you have to come back down from Baur
-      DoubleJump, TripleJump, Sword OR Hammer
     unsafe, LowerReach.BearSneezed, LowerReach.BearBridgeBroken:
+      Bash  # bash the enemy into the air first, may have to use the purple one
       Grenade=1  # GrenadeJump=1
       # you only get one shot at these else you have to come back down from Baur
-      Dash, DoubleJump, Shuriken=1 OR Flash=1 OR Spear=1 OR Sentry=1 OR Blaze=1  # A single activation of flash
-      DoubleJump, TripleJump, Flash=1 OR Sentry=1 OR Shuriken=1
+      Dash, DoubleJump, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Spear=1 OR Sentry=1 OR Blaze=1  # A single activation of flash
+      DoubleJump, TripleJump, Sword OR Hammer OR Flash=1 OR Sentry=1 OR Shuriken=1
 
   conn LowerReach.AboveEntry:
     moki:
@@ -3962,8 +3961,8 @@ anchor LowerReach.Entry at -390, -4025:  # Behind Baur
       Bash, DoubleJump OR Launch OR Dash OR Grenade=1
     gorlek:
       Launch  # a little tight but totally doable. Jump up before launching.
-      Bash, Sword OR Glide OR Hammer OR SentryJump=1 OR Damage=20  # There is a safe spot at the left of the spike before the first lantern
-      SentryJump=1, DoubleJump
+      Bash, Glide, Damage=20
+      SentryJump=1, DoubleJump OR Bash
     unsafe:
       SentryJump=1
       Bash  # can be done damageless, but damage is likely. Keep jumping at the right wall until you go over it and bash the first latern at just the right angle to reach the second
@@ -3980,9 +3979,9 @@ anchor LowerReach.AboveEntry at -401, -4000:  # On the platform above Baur insid
     gorlek:
       LowerReach.HeatBaurFurnace, Dash
       LowerReach.HeatBaurFurnace, Bash, Grenade=1
-      Bash, Grenade=1, DoubleJump OR Dash
     unsafe:
       LowerReach.HeatBaurFurnace, Sword OR Hammer OR Glide
+      Bash, Grenade=1, DoubleJump OR Dash OR Glide OR Sword OR Hammer # Use the plant as a platform
       SentryJump=1  # you actually want a weaker jump to land on top of the plant, a strong one will send you sailing over it. Weapon stalls or dash/doublejump from there
       Bash, Sword OR Hammer OR DoubleJump OR Dash OR Glide OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       DoubleJump, TripleJump, Damage=20 OR Sword OR Hammer  # you need first to get on the first plant on the left
@@ -3998,8 +3997,12 @@ anchor LowerReach.AboveEntry at -401, -4000:  # On the platform above Baur insid
       Bash, Grenade=1 OR SentryJump=1
       SentryJump=2
     unsafe:
-      LowerReach.HeatBaurFurnace, Bash  # weapon stalling! Not really that hard, maybe gorlek ok
+      SentryJump=1, DoubleJump #sjump, climb the left wall then djump + up slash + weapon stall to reach the xp
+      DoubleJump, TripleJump # Climbing frozen tongue with TripleJump
+      LowerReach.HeatBaurFurnace, Bash, Sword OR Hammer  # weapon stalling! Not really that hard, maybe gorlek ok
+      LowerReach.HeatBaurFurnace, DoubleJump, TripleJump OR Sword OR Hammer
       Bash  # jump repeated under the left side of the snaptrap to aggro the spitter. yes, really.
+      DoubleJump, Dash #From the left of the frozen tongue, coyote dash+doublejump+dash. Jump off the tongue asap, djump+dash. Climb the left wall then djump + dash
   pickup LowerReach.AboveBaurUpperEX:
     moki:
       Launch
@@ -4007,25 +4010,35 @@ anchor LowerReach.AboveEntry at -401, -4000:  # On the platform above Baur insid
     gorlek:
       LowerReach.HeatBaurFurnace, DoubleJump, Bash
     unsafe:
-      LowerReach.HeatBaurFurnace, Dash, Bash  # get up to the snaptrap with the LowerReach.AboveBaurLowerEX then dash and weapon stall to the tongue plant
-      LowerReach.HeatBaurFurnace, SentryJump=2, Damage=20  # First jump into the spikes near the shooter, can use lower jump to snaptrap - wall - weapon stall to spikes, then sentry up from spikes to the tongue plant
-      LowerReach.HeatBaurFurnace, Bash, Glide  # get up to the snaptrap with the LowerReach.AboveBaurLowerEX, glide down over the shooter, bash off its projectile
-      LowerReach.HeatBaurFurnace, Bash, Grenade=1  # charge the grenade on the snaptrap by the spikes
-
+      LowerReach.HeatBaurFurnace, DoubleJump, TripleJump OR Sword OR Hammer
+      LowerReach.HeatBaurFurnace, SentryJump=2, DoubleJump OR Damage=20  # First jump into the spikes near the shooter, can use lower jump to snaptrap - wall - weapon stall to spikes, then sentry up from spikes to the tongue plant
+      LowerReach.HeatBaurFurnace, SentryJump=2, Sword #Pogo the shooter to make it to the left wall, move a bit away from it then sjump+upslash to reach the tongue
+      LowerReach.HeatBaurFurnace, SentryJump=1, Dash # up slash + dash to reach the left wall. Move a bit away from it, sjump to reach the tongue
+      LowerReach.HeatBaurFurnace, Bash #jump repeated under the left side of the snaptrap to aggro the spitter. On the second snaptrap, bash the projectile upwards then jump to it and bash to AboveBaurLowerEX. If you stayed long enough on the snaptrap, the shooter should shot a new projectile which you can use to grab the tongue.
   conn LowerReach.Entry: free
   conn LowerReach.Icefall:
     moki:
       DoubleJump OR Launch OR Dash
       LowerReach.HeatBaurFurnace
-    unsafe: Bash  # jump to aggro the spitter (or use grenade) and catch high up on the frozen tongue, then jump off quickly
+    unsafe: 
+      Sentry=2 OR Shuriken=2
+      Sword OR Hammer # Upslash before grabing the frozen tongue, jump out of it then weapon stall
+      Bash  # jump to aggro the spitter (or use grenade) and catch high up on the frozen tongue, then jump off quickly
   conn LowerReach.Central:
     moki, LowerReach.Lever:
       Bash, DoubleJump OR Dash OR Glide
       Launch
     gorlek, LowerReach.Lever:
-      Bash  # aim high and weapon stall
+      DoubleJump, TripleJump OR Dash
+      Glide, DoubleJump OR Dash
     unsafe, LowerReach.Lever:
-      Dash  # slide down the wall and dash away, then dash again and weapon stall
+      Bash, Sword OR Hammer OR Damage=20 # aim high and weapon stall
+      Glide, Damage=20 OR Sword OR Hammer
+      Dash, Sword OR Hammer OR Damage=20
+      DoubleJump, Sword OR Damage=20
+      Sword, Damage=20
+      Glide, Sentry=1 OR Shuriken=1 OR Flash=1
+      Dash, Shuriken=1 OR Sentry=2 # Dash on the small wall from the branch where the lantern is attached, dash again then stall with sentry/shuriken
 
 anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's nose
   refill Checkpoint
@@ -4040,8 +4053,13 @@ anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's n
       Grenade=1, Launch  # Grenade to light the furnace
       Grenade=1, Grapple, DoubleJump OR Dash OR Glide  # Grenade to light the furnace
     gorlek:
-      Grenade=1, Bash OR Grapple  # grapple alone requires some weapon stalling
-
+      Grenade=1, Bash
+      Grenade=1, Grapple, Sword OR Hammer # Weapon stall after grabing the plant. Use sword/hammer to combat the Bees as well
+      Grenade=1, SentryJump=1, Combat=Nest
+    unsafe:
+      Grenade=1, Combat=Nest, Damage=20 # Damage boost on the spikes on the frozen waterfall
+      Grenade=1, DoubleJump, Combat=Nest
+      Grenade=1, Grapple, Sentry=1 OR Shuriken=1
   pickup LowerReach.IcefallOre:
     moki, LowerReach.LeftFurnace:
       Bash, Grapple OR Launch  # bash the enemies
@@ -4050,8 +4068,14 @@ anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's n
     gorlek, LowerReach.LeftFurnace:
       Water, WaterDash, DoubleJump, TripleJump
       Bash
-      Grapple, Damage=10  # weapon stall needed, probably get hit by wasps
+      Grapple, Damage=10, Sword OR Hammer OR DoubleJump OR Dash OR Glide # weapon stall needed, probably get hit by wasps
       Launch, Damage=10
+    unsafe:
+      WaterDash, DoubleJump, TripleJump, Damage=20
+      WaterDash, DoubleJump, Water, Sword OR Hammer
+      WaterDash, DoubleJump, Damage=20, Sword OR Hammer
+      Combat=Nest, SentryJump=1, DoubleJump, TripleJump, Sword OR Dash # With sword, running sjump +tjump+upslash
+  
   pickup LowerReach.IcefallEX:
     moki, LowerReach.LeftFurnace:
       DoubleJump, Bash  # bash the enemies
@@ -4059,25 +4083,34 @@ anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's n
       Combat=2xSlug, Water, DoubleJump, WaterDash  # swim past the enemies
       Launch
     gorlek, LowerReach.LeftFurnace:
-      Water, Sword  # Pogo a fish
-      Water, WaterDash, DoubleJump OR Hammer OR Damage=20
-      Damage=20, DoubleJump, TripleJump OR Sword OR Hammer
-      Damage=20, WaterDash, DoubleJump OR Sword OR Hammer
-      Grapple, DoubleJump OR Sword OR Hammer
-      Grapple, Damage=20, Dash OR Glide
-      Bash, Sword OR Hammer OR Damage=20
-      SentryJump=1, DoubleJump OR Dash OR Glide
+      Water, WaterDash, DoubleJump
+      Water, DoubleJump, TripleJump
+      Damage=20, DoubleJump, TripleJump # dboost in the poisonous water
+      Damage=20, WaterDash, DoubleJump
+      Grapple, DoubleJump
     unsafe, LowerReach.LeftFurnace:
+      Grapple, Damage=20, Dash OR Glide
+      Combat=Nest, SentryJump=1, Sword, DoubleJump OR Dash OR Glide
+      Combat=Nest, SentryJump=1, Glide, Dash OR DoubleJump
+      Combat=Nest, SentryJump=1, Dash, DoubleJump
+      Bash, Sword OR Hammer OR Damage=20
+      Grapple, Sword OR Hammer
+      Sword, Water # Pogo a fish
+      Water, WaterDash, Damage=20 OR Hammer
+      WaterDash, Damage=20, Sword OR Hammer
+      WaterDash, Hammer, Water OR Damage=20
       Water, WaterDash, Flash
       Water, WaterDash, Sentry=1
       Water, WaterDash, Spear=1
-      Water, WaterDash, Bash  # Using moskitos lure
+      Water, WaterDash, Bash # Using moskitos lure
 
   conn LowerReach.Entry: free
   conn LowerReach.AboveEntry:
     moki:
       DoubleJump OR Launch OR Dash
       LowerReach.HeatBaurFurnace
+    unsafe:
+      Glide OR Sword OR Hammer # From the same height as the water
 
 anchor LowerReach.Central at -335, -4010:  # After the lever door
   refill Checkpoint
@@ -4088,12 +4121,18 @@ anchor LowerReach.Central at -335, -4010:  # After the lever door
       Bash, Grenade=1
       Launch
     gorlek:
-      Bash
+      Bash, Grenade=1
       SentryJump=1
       DoubleJump, TripleJump
     unsafe:
-      DoubleJump  # annoying but doable, requires upslash
+      Bash
+      DoubleJump, LowerReach.Lever OR Sword # With sword, pogo the slime
       Grenade=1  # GrenadeJump=1
+      LowerReach.CentralFurnace:
+        DoubleJump, Sword, Bash OR Spear=1
+        DoubleJump, Hammer #use the plant up slash and directly wall jump on the left wall
+        Dash, Glide, Hammer # jump->up slash->dash->glide
+        Dash, Sword, Hammer OR Spear=1 #Dash ramp from under the pickup then dash again and weapon stall
   pickup LowerReach.LupoMap:
     moki:
       Launch
@@ -4103,8 +4142,9 @@ anchor LowerReach.Central at -335, -4010:  # After the lever door
       DoubleJump, TripleJump
       SentryJump=1  # from the snaptrap
     unsafe:
+      DoubleJump, Sword OR Hammer #sword: weapon stalling / hammer: djump+upslash from the snaptrap
       Bash  # move the purple slug to the right first
-      DoubleJump, Glide  # from LowerReach.AboveDoorEX
+      DoubleJump, Glide, LowerReach.Lever  # from LowerReach.AboveDoorEX
       Grenade=1  # GrenadeJump=1
   pickup LowerReach.TPLeftEX:
     moki:
@@ -4113,13 +4153,15 @@ anchor LowerReach.Central at -335, -4010:  # After the lever door
       LowerReach.CentralFurnace, Bash, Grenade=1, DoubleJump OR Dash OR Glide
       Bash, Grenade=2, Hammer OR Spear=1
     gorlek:
-      Bash, Hammer OR Spear=1
       SentryJump=2, Hammer OR Spear=1
-      DoubleJump, TripleJump, Hammer OR Spear=1  # finish with an upswing
+      DoubleJump, TripleJump, LowerReach.Lever, Hammer OR Spear=1  # finish with an upswing
     unsafe:
+      Bash, Hammer OR Spear=1
       Grenade=2, Hammer OR Spear=1  # GrenadeJump=2, Hammer OR Spear=1
-      Spear=1, SentryJump=1
-
+      LowerReach.CentralFurnace:
+        DoubleJump, Sword OR Hammer OR TripleJump #With Hammer, need to wall jump to get on the branch near the mortal then jump out of it and air stall
+        Dash, Glide, Hammer OR Sword
+        Grenade=1, Bash
   conn LowerReach.SecondSoup: free
   conn LowerReach.OutsideTPRoom:
     moki:
@@ -4127,12 +4169,17 @@ anchor LowerReach.Central at -335, -4010:  # After the lever door
       LowerReach.CentralFurnace, DoubleJump, Dash, Bash
       LowerReach.CentralFurnace, Bash, Grenade=1
     gorlek:
-      Bash, Hammer OR Spear=1
-      SentryJump=2, Hammer OR Spear=1
+      SentryJump=3, Hammer OR Spear=1
       LowerReach.CentralFurnace, DoubleJump, TripleJump OR Dash  # stand on the tongue plant
     unsafe:
-      LowerReach.CentralFurnace, Bash  # move the purple slug to the right first
+      DoubleJump, TripleJump, LowerReach.Lever, Hammer OR Spear=1
+      DoubleJump, TripleJump, Sword, Hammer OR Spear=1 #Pogo the slime
+      Bash, Hammer OR Spear=1
       Grenade=2, DoubleJump, Hammer OR Spear=1  # GrenadeJump=2, DoubleJump, Hammer OR Spear=1
+      LowerReach.CentralFurnace, Bash  # move the purple slug to the right first
+      LowerReach.CentralFurnace, SentryJump=2
+      LowerReach.CentralFurnace, DoubleJump, Hammer OR Sword
+      LowerReach.CentralFurnace, Dash, Hammer #dash ramp->up slash->dash->weapon stall to grab the tongue
 
 anchor LowerReach.OutsideTPRoom at -311, -3970:  # To the left of the teleporter room
   refill Checkpoint
@@ -4152,33 +4199,45 @@ anchor LowerReach.OutsideTPRoom at -311, -3970:  # To the left of the teleporter
     moki:
       Bash, DoubleJump OR Dash OR Glide
       Launch
-    gorlek: Bash OR Glide OR Dash OR DoubleJump OR SentryJump=1  # weapon stalling may be needed
-    unsafe: Grenade=1  # GrenadeJump=1
+    gorlek:
+      Glide OR SentryJump=1
+      DoubleJump, Dash OR TripleJump OR Sword OR Hammer
+      Dash, Sword OR Hammer
+    unsafe:
+      Grenade=1  # GrenadeJump=1
+      Bash OR Sword OR Hammer OR DoubleJump OR Dash
   pickup LowerReach.HiddenOre:
     moki:
       Launch
       LowerReach.CentralFurnace, DoubleJump, Bash, Dash OR Glide OR Grenade=1
     gorlek:
-      LowerReach.CentralFurnace, SentryJump=1  # highest jump can go all the way, middling can reach tongue plant, low can reach snaptrap then weaponstall to tongue
-      LowerReach.CentralFurnace, Bash, Grenade=1 OR Glide OR DoubleJump OR Dash
+      LowerReach.CentralFurnace, DoubleJump, Bash OR SentryJump=1
     unsafe:
       LowerReach.CentralFurnace, Bash  # stand beside the spitter, bash off it once it shoots, then again off the projectile
-      LowerReach.CentralFurnace, TripleJump, Damage=20  # jump onto the spikes then up to the snaptrap
       SentryJump=1
+      DoubleJump, TripleJump, Damage=20  # jump onto the spikes then up to the snaptrap. Jump on the tongue, let ori slide down then double jump again and go for the right wall
+      Bash, DoubleJump, TripleJump OR Dash OR Sword OR Hammer OR Glide #jump on the tongue, let ori slide down then double jump again and go for the right wall with dash/up slashes/glide, climb it, grab the tongue again and jump out of it
 
   conn LowerReach.SecondSoup: free
   conn LowerReach.Central:
     moki: DoubleJump OR Dash OR Bash OR Glide OR Launch OR Hammer OR Spear=1
-    unsafe: free
+    gorlek: free
   conn UpperReach.KeystoneRoom:
     moki:
       DoubleJump, Dash, Bash  # bash the squonkey
       DoubleJump, Bash, Grenade=2  # bash the squonkey
       Launch
     gorlek:
+      SentryJump=2, DoubleJump #use weapon stall as well
+      SentryJump=1, DoubleJump, Dash #djump+dash from the frozen snaptrap
       Bash, Grenade=1, Dash OR Glide OR DoubleJump  # use the spitter projectile to get a higher bash off your grenade
     unsafe:
+      Bash, Dash OR DoubleJump OR Sword OR Hammer #juggle the mortar shot than bash the squonkey
       Bash, Grenade=1 OR DoubleJump OR Dash
+      DoubleJump, TripleJump #Need to start jumping just under the energy cristal to get to the first snaptrap
+      SentryJump=1, DoubleJump, LowerReach.CentralFurnace #djump+dash from the frozen snaptrap / bait the last snaptrap and double jump + use weapon to stall in the air
+      SentryJump=1, DoubleJump, Hammer, Glide #double jump+upslash from the plant to get near the burrow section, climb it then glide to the right
+      
   conn LowerReach.Teleporter:
     moki: Grenade=1
     gorlek, glitch: Sentry=1
@@ -4192,6 +4251,507 @@ anchor LowerReach.Teleporter at -259, -3962:  # This has to exist to support the
     gorlek, glitch: Sentry=1
 
 # checkpoint at -296, -3944
+
+anchor LowerReach.SecondSoup at -316, -4037:  # Next to the soup below the teleporter
+  state LowerReach.CentralFurnace:
+    moki:
+      Combat=ShieldMiner, DoubleJump, Dash, Bash, Flap
+      Grenade=1, Combat=ShieldMiner OR Bash OR Burrow OR Launch
+    gorlek:
+      Bash, Flap, Combat=ShieldMiner OR Dash OR Launch
+      Grenade=1, DoubleJump OR Dash OR Glide
+    unsafe:
+      Bash, Flap
+
+  pickup LowerReach.MeltIceEX:
+    moki: Grenade=1
+    gorlek: Bash, Flap
+    gorlek, glitch: Sentry=1
+  pickup LowerReach.BurrowEX:
+    moki: Burrow, DoubleJump OR Dash OR Glide OR Launch
+    gorlek: Burrow  # Need to TP out to avoid falling into spikes. Sword OR Hammer OR Damage=20 OR Shuriken=1 to airstall otherwise
+
+  conn LowerReach.Central:
+    moki:
+      DoubleJump, Bash, Flap OR Grenade=1
+      DoubleJump, Burrow
+      Launch
+    gorlek:
+      DoubleJump, Bash
+      Bash, Dash, Grenade=1 OR Flap  # With flap, need to juggle the projectile
+      SentryJump=1
+    unsafe:
+      Bash, Grenade=1 OR Flap #Bash the ShieldMiner before bashing your grenade or soup's projectile
+      DoubleJump  # Need to jump from the highest point on the cauldron when it's at his highest point (can just jump on the spot to make the cauldron reach that point)
+ 
+  conn LowerReach.WindChannel:
+    moki:
+      Combat=ShieldMiner OR Bash OR Launch
+      Burrow, DoubleJump OR Dash OR Glide
+    unsafe:
+      Burrow # Pass under the ShieldMiner 
+
+anchor LowerReach.WindChannel at -256, -4035:  # The furnace left of the wind channel connecting to east reach
+  refill Checkpoint
+  refill Energy=3:
+    moki, Weapon:
+      Combat=ShieldMiner, DoubleJump OR Dash
+      Bash OR Launch
+    gorlek: Weapon
+
+  state LowerReach.CentralFurnace:
+    moki: Grenade=1
+
+  pickup LowerReach.BelowLupoEX:
+    moki:
+      DoubleJump, Bash, Grenade=1
+      Launch
+      LowerReach.CentralFurnace, DoubleJump OR Dash
+    gorlek:
+      SentryJump=1, DoubleJump OR Dash OR Damage=20 # sjump from the frozen plant
+      Grenade=1, Bash, DoubleJump OR Damage=20
+      LowerReach.CentralFurnace, Damage=20, Glide OR Sword OR Hammer
+    unsafe:
+      LowerReach.CentralFurnace, Damage=20 OR Glide OR Sword OR Hammer
+      Grenade=1, Bash, Dash OR Sword OR Glide
+      Flap, Bash, Damage=20 OR DoubleJump OR Dash OR Sword OR Glide
+      SentryJump=1 # sjump from the frozen plant then upslash
+  pickup LowerReach.BreakWallEX:
+    moki, BreakWall=20:
+      Combat=ShieldMiner OR Bash OR Launch
+      DoubleJump, Dash OR Glide
+    unsafe:
+      BreakWall=20 # jump over the gorlek when it's near the anchor
+  pickup LowerReach.WindBottomEX:
+    moki: Grenade=1, Glide  # grenade to light the lantern
+    gorlek:
+      Grenade=1, Damage=20 # TP out
+    gorlek, glitch:  # Sentry to light the lantern
+      Sentry=1, Glide, Launch OR SentryJump=1
+      Sentry=1, Damage=20, Launch OR SentryJump=1 #without launch, tp out
+      Sentry=1, DoubleJump, TripleJump, Glide OR Damage=20  # jump bellow the lantern, don't need any wall jump
+    unsafe:
+      Grenade=1 # TP out
+    unsafe, glitch:
+      Sentry=1, DoubleJump  # djump + sentry to light the lantern. The sentry need to explode when the butterfly is high (rng based?)
+  pickup LowerReach.WindHiddenEX:
+    moki: Grenade=1, Glide  # grenade to light the lantern
+    gorlek: 
+      Launch, Damage=20, DoubleJump OR Dash
+      Launch, DoubleJump, Dash OR Glide
+    gorlek, glitch:  # sentry to light the lantern
+      DoubleJump, TripleJump, Sentry=1, Glide
+      Sentry=1, Glide, SentryJump=1 OR Launch
+    unsafe:
+      Launch, Sword OR Dash OR DoubleJump
+      DoubleJump, TripleJump, Damage=20, Sword OR Hammer OR Bash  # tjump + upslash/bash the gorlek to climb the right wall, tjump to the left spiky wall, iframe to wjump and tjump again to wjump from the wall just above and tjump again to the ice wall<
+      SentryJump=2, Damage=20, DoubleJump OR Dash  # sjump, damage boost (the spikes wond t hit Ori after landing on them), sjump again then upsalsh to reach the right wall then sword combo to reach the pickup and tp out
+      DoubleJump, TripleJump, SentryJump=1, Damage=20  # same as above, triple jump + up slash to get to the right wall then jump into the spikes to avoid the first sjump
+    unsafe, glitch:
+      DoubleJump, Sentry=1, Glide, Hammer
+  conn LowerReach.SecondSoup:
+    moki:
+      Combat=ShieldMiner, DoubleJump OR Dash OR Glide
+      Bash, Grenade=1
+      Launch
+    gorlek: Combat=ShieldMiner
+  conn LowerReach.SoupMoki:
+    moki: Grenade=1, Glide  # grenade to light the lantern
+    gorlek: Launch, DoubleJump OR Dash OR Damage=20
+    gorlek, glitch:  # Sentry to light the lantern
+      DoubleJump, TripleJump, Sentry=1, Glide
+      Sentry=1, Glide, SentryJump=1 OR Launch
+    unsafe: Launch
+    unsafe, glitch: DoubleJump, Hammer, Sentry=1, Glide
+
+# checkpoint at -223, -4043
+
+anchor LowerReach.SoupMoki at -240, -3989:  # Below the reach teleporter, where you hand delicious marshclam soup to a moki (or alternatively extuingish his fireplace...)
+  refill Energy=4:
+    moki: Weapon
+
+  quest LowerReach.HandToHandHat:
+    moki: GladesTown.HandToHandSoup
+
+  pickup LowerReach.WindHiddenEX:
+    moki:
+      DoubleJump, Dash, Glide
+      Launch, Glide
+    gorlek: DoubleJump OR Dash OR Glide OR Launch OR Damage=20 # TP out
+    unsafe:
+      Sword OR Flash=1 OR Sentry=1 OR Shuriken=1
+      Bash, Grenade=1
+
+  conn LowerReach.WindChannel:
+    moki: Glide
+    gorlek: DoubleJump OR Dash OR Launch OR Sword OR Hammer OR Damage=20  # Can use Shuriken, Flash, Bow, Spike, Sentry to slow you down so you can avoid taking a damage (gorlek?)
+    unsafe: free
+  conn LowerReach.East:
+    moki:
+      DoubleJump, Dash, Bash, Grenade=2
+      Launch
+    gorlek:
+      SentryJump=2, DoubleJump, Sword
+      DoubleJump, TripleJump, Bash, Grenade=2
+    unsafe:
+      Bash, Grenade=1 # Bash the slime 
+      SentryJump=2
+      DoubleJump, TripleJump, Dash OR Sword  # climb the wall near the moki, dash then triple jump to the wall to reset your jumps and dash + triple jump to reach the plant. With sword, pogo the fire, triple jump + upslash to reach the wall to reset your jumps then sword jump to the plant
+
+anchor LowerReach.East at -182, -3968:  # Right of the Lantern opening the Tp room
+  refill Checkpoint
+  refill Full:  # use the teleporter
+    moki: Bash, Grenade=2, DoubleJump OR Dash OR Glide OR Launch
+    gorlek:
+      Bash, Grenade=2
+      Grenade=1, DoubleJump OR Dash OR Glide OR Launch OR Sword #Grenade to light the lanterne, use the rest to pass the gap
+    gorlek, glitch:
+      Sentry=1, Launch
+      Sentry=1, SentryJump=1, Sword
+      Sentry=1, DoubleJump, TripleJump
+    unsafe:
+      Grenade=1, Hammer OR Sentry=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Spear=1
+    unsafe, glitch:
+      Sentry=1, SentryJump=1
+      Sentry=1, DoubleJump, Hammer
+  # could be considered moving this anchor to the left, closer to the teleporter, if it gets important on higher difficulties
+
+  state LowerReach.RolledSnowball:
+    moki: Grenade=1, Combat=Mantis OR Bash
+    gorlek, glitch:  # Sentry to melt the ice
+      Launch, Sentry=1
+      DoubleJump, TripleJump, Sentry=1, Glide
+    unsafe, glitch:
+      DoubleJump, TripleJump, Sentry=1, Dash OR Sword OR Hammer OR Damage=20 # Jump from the branch above the ice, triple jump to get close enough, sentry to melt the ice then return to safety
+      Damage=20, SentryJump=1, Sentry=1  # Jump in the spikes (won't damage Ori afterwards), sjump then sentry to melt the ice + sword combo to return to safety
+      DoubleJump, TripleJump, Sentry=1, Shuriken=1 OR Blaze=1
+      DoubleJump, TripleJump, Sentry=2  # Same path as above but use one sentry to stall in the air and another one to melt the ice
+
+  pickup LowerReach.SnowballHC:
+    moki: LowerReach.RolledSnowball, Burrow, DoubleJump OR Dash OR Glide OR Launch OR Damage=20
+    gorlek: LowerReach.RolledSnowball, Burrow  # Dash in the snow before exiting the burrow section to get momentum
+
+  conn LowerReach.Teleporter:
+    moki: Bash, Grenade=2, DoubleJump OR Dash OR Glide OR Launch
+    gorlek:
+      Bash, Grenade=2
+      Grenade=1, DoubleJump OR Dash OR Glide OR Launch OR Sword #Grenade to light the lanterne, use the rest to pass the gap
+    gorlek, glitch:
+      Sentry=1, Launch
+      Sentry=1, SentryJump=1, Sword
+      Sentry=1, DoubleJump, TripleJump
+    unsafe:
+      Grenade=1, Hammer OR Sentry=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Spear=1
+    unsafe, glitch:
+      Sentry=1, SentryJump=1
+      Sentry=1, DoubleJump, Hammer
+  conn LowerReach.SoupMoki: free
+  conn LowerReach.PastSnowball:
+    moki, LowerReach.RolledSnowball:
+      DoubleJump OR Glide OR Launch
+      Bash, Grenade=1, Dash
+      Bash, Grenade=2
+    gorlek, LowerReach.RolledSnowball: Dash OR Sword OR Hammer OR Damage=20  # Bash the running ennemy to avoid the damage boost
+    unsafe, LowerReach.RolledSnowball: Bash OR Grenade=1 OR Sentry=1 OR Shuriken=1 OR Flash=1 OR Blaze=1 OR Spear=1
+
+anchor LowerReach.PastSnowball at -99, -3982:  # At the bashnade pedestal after rolling the snowball
+  refill Checkpoint
+  refill Energy=4:  # fast respawning crystal
+    moki: Weapon
+
+  state LowerReach.EastDoorLantern:
+    moki:
+      Bash, Grenade=2, DoubleJump, Dash, Glide
+      Grenade=1, Launch
+    gorlek:
+      SentryJump=1, DoubleJump, Grenade=1, Sword # use air stalling as well
+      SentryJump=4, Grenade=1, Sword
+      Bash, Grenade=2, DoubleJump, TripleJump OR Dash OR Glide OR Sword
+    gorlek, glitch:
+      Sentry=1, Launch
+    unsafe:
+      Bash, Grenade=2, DoubleJump, Hammer
+      Bash, Grenade=5, Damage=20
+      Bash, Grenade=3, DoubleJump
+      Bash, Grenade=4, Dash OR Sword
+      Bash, Grenade=5, Glide OR Hammer
+      SentryJump=2, Grenade=1, Glide OR Dash  # Need to use up slashes
+      DoubleJump, TripleJump, Grenade=1  # Need to get a really precise wall jump to get to the plants
+    unsafe, glitch:
+      SentryJump=3, Sentry=1, Sword, Glide OR Dash
+      DoubleJump, TripleJump, Sentry=1
+      SentryJump=5, Sentry=1, Sword
+      SentryJump=1, DoubleJump, Sentry=1, Sword
+  pickup LowerReach.RoofLeftEX:
+    moki:
+      LowerReach.CoolEastFurnace, Bash, Grenade=2, DoubleJump, Dash, Glide  # blame moon
+      Launch, DoubleJump, Dash OR Glide
+      Bash, Grenade=1, Launch
+    gorlek:
+      Launch, DoubleJump # Easier from under the snaptrap
+    unsafe:
+      SentryJump=1, DoubleJump, TripleJump, Sword
+      Bash, Grenade=2, DoubleJump, TripleJump OR Dash OR Glide
+      Launch, Dash OR Glide OR Sword OR Hammer  # Launch on the ceiling, use your mobility option then launch again
+      SentryJump=1, DoubleJump, Dash
+      Launch, Shuriken=2 OR Sentry=2  # Launch on the ceiling, sentry/shuriken -> launch -> sentry/shuriken again
+  pickup LowerReach.RoofRightEX:
+    moki:
+      LowerReach.CoolEastFurnace, Bash, Grenade=2
+      Launch
+    gorlek:
+      SentryJump=2, Sword
+    unsafe:
+      Bash, Grenade=2
+      DoubleJump, TripleJump  # Need to get a really precise wall jump to get to the plants
+      Bash, Grenade=1, DoubleJump, Dash # Climb on the right wall above the 2nd plant
+      SentryJump=1, DoubleJump  # Climb on the wall above the 2nd plant
+
+  conn LowerReach.SwimmingPool:
+    moki:
+      Bash, Grenade=1, DoubleJump, Dash, Glide
+      Launch
+    gorlek:
+      ShurikenBreak=20
+      SentryJump=1, DoubleJump, Sword
+      SentryJump=3, Sword
+      Bash, Grenade=1, DoubleJump, Damage=20, TripleJump OR Dash OR Glide
+    unsafe:
+      Bash, Grenade=2, Dash
+      Bash, Grenade=3, Glide
+      Bash, Grenade=1, DoubleJump, Damage=20 OR TripleJump OR Dash OR Glide OR Sword OR Hammer
+      SentryJump=1, DoubleJump, Sword, Dash OR Glide
+      DoubleJump, TripleJump  # Need to get a really precise wall jump to get to the plants
+      Bash, Grenade=1, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR LowerReach.HeatEastFurnace  # Need to walljump on the wall above the 2nd plant then dash, get a reset by touching the ceilin and dash a second time
+    # shuriken break note: this wall has 20 health
+  # backwards path can't get past the snowball
+
+# checkpoint at -60, -3987
+
+anchor LowerReach.SwimmingPool at -44, -4001:  # At the platform in the freezable water
+  refill Energy=4:
+    moki: Weapon, LowerReach.CoolEastFurnace OR Water
+
+  state LowerReach.HeatEastFurnace:
+    moki:
+      Bash, Grenade=2
+      Grenade=1, Launch
+    gorlek:
+      DoubleJump, TripleJump, Grenade=1  # Climb the right wal then jump to the left wall before double jumping again to the platform
+      SentryJump=1, Grenade=1
+    unsafe: DoubleJump, Grenade=1  # Precise wall jump on the right wall then wjump on the left wall
+  state LowerReach.CoolEastFurnace:  # the intentional path is to cool this furnace
+    moki:
+      Flap, Bash, Grenade=1
+      Flap, Launch
+    gorlek:
+      DoubleJump, TripleJump, Flap  # Climb the right wal then jump to the left wall before double jumping again to the platform
+      SentryJump=1, Flap, Sword OR Dash OR DoubleJump
+      LowerReach.HeatEastFurnace, WaterDash, Flap, Water OR Damage=20
+    unsafe: DoubleJump, Flap  # Precise wall jump on the right wall then wjump on the left wall
+
+  pickup LowerReach.FractureShard:
+    moki: LowerReach.HeatEastFurnace, Water
+
+  conn LowerReach.ArenaArea:
+    moki, LowerReach.EastDoorLantern:
+      LowerReach.CoolEastFurnace, Bash, Grenade=1
+      Launch, LowerReach.CoolEastFurnace OR DoubleJump OR Dash OR Glide
+    gorlek, LowerReach.EastDoorLantern:
+      Launch  # Launch into the ceiling then into the wall near the energy cristal and again to the platform
+      SentryJump=1, LowerReach.CoolEastFurnaced
+      SentryJump=1, Water, Sword
+      SentryJump=2, DoubleJump, Glide, Sword
+      LowerReach.HeatEastFurnace, WaterDash, Water, DoubleJump  # Wall jump from the right wall
+    unsafe:
+      LowerReach.HeatEastFurnace, WaterDash, Water, Hammer  # Wall jump from the right wall
+      Bash, Grenade=1, Water
+      SentryJump=1, Sword, DoubleJump, TripleJump OR Dash OR Glide # double jump from the platform, refill dash/jumps by slashing the energy cristal then sjump on the plant
+      SentryJump=2, Sword, DoubleJump OR Glide OR Dash
+      Bash, Grenade=1, Damage=20, DoubleJump OR Dash
+      Bash, Grenade=1, Damage=20, WaterDash, Glide OR Sword  # Jump, air stall, damage boost to waterdash and air stall again
+      Bash, Grenade=1, DoubleJump, Sword, TripleJump OR Dash OR Glide
+      Bash, Grenade=2, Damage=20 OR Dash OR Glide
+      Bash, Grenade=2, Sword, DoubleJump OR Dash
+      Bash, Grenade=2, Hammer, DoubleJump OR Dash
+  conn LowerReach.PastSnowball:
+    moki, BreakWall=20:
+      Bash, Grenade=1
+      Launch
+    gorlek, BreakWall=20:
+      DoubleJump, TripleJump  # Climb the right wal then jump to the left wall before double jumping again to the platform
+      SentryJump=1, Sword OR Dash OR DoubleJump
+      LowerReach.HeatEastFurnace, WaterDash, Water OR Damage=20
+    unsafe: DoubleJump, BreakWall=20 # Precise wall jump on the right wall then wjump on the left wall
+
+anchor LowerReach.ArenaArea at 44, -3992:  # To the left of the combat arena
+  refill Checkpoint
+  refill Health=1
+  refill Energy=3:
+    moki:
+      Weapon, DoubleJump, Dash
+      Weapon, Launch
+      Bow=1 OR Spear=1 OR Grenade=1
+
+  state LowerReach.ArenaBeaten:
+    moki: Regenerate, Damage=40, Combat=3xShieldMiner+Hornbug+2xBee
+    unsafe: Combat=3xShieldMiner+Hornbug+2xBee
+
+  conn LowerReach.Trial:
+    moki: LowerReach.ArenaBeaten
+  conn LowerReach.WispPath:
+    moki, LowerReach.ArenaBeaten:
+      Glide, Grapple OR Launch
+      Glide, DoubleJump, Bash, Grenade=1
+    gorlek, LowerReach.ArenaBeaten:
+      Glide, SentryJump=1
+      Glide, Bash, Grenade=1
+      Glide, DoubleJump, TripleJump OR Sword OR Hammer OR Dash OR Damage=20  # With dboost, jump in the spike wall then djump
+      Launch, DoubleJump, TripleJump OR Damage=20  # Pass the 3 first spinner, wall jump on the right wall, djump, launch under the spinner, djump again to reach the wall. Possible with only djump but adding tjump/damage to make it easier for a gorlek player.
+    unsafe, LowerReach.ArenaBeaten:
+      Glide, Dash, Hammer
+      Launch, Dash OR Sword OR Shuriken=1 OR Sentry=1 OR Spear=1 OR Flash=1 OR Damage=20 # Pass the 3 first spinner, wall jump on the right wall, stall, launch into the ceiling, relaunch on the left wall
+      DoubleJump, TripleJump, Damage=20, Dash OR Sword OR Hammer OR Shuriken=2 OR Sentry=2 OR Flash=2 OR Blaze=2 OR Spear=2  # Climb the right wall, triple jump + stall to the left wall, return to the right before the 2nd spinner, climb  the left wall after the 3rd spinner, stall as much possible in the air, take a damage boost on the spike floor then go to the right wall. You can saty on the right wall and climb to the energy cristal with triple jump
+      Bash, Grenade=2, DoubleJump, TripleJump, Damage=20  # Same as above. 1st bash grenade to access directly to the left wall in the arena and second one just after the 3rd spinner
+  # backwards path can't get through the door
+
+# checkpoint at just kidding, placed this mark because the refill logic below kind of sucks
+
+anchor LowerReach.WispPath at 83, -3874:  # Halfway through the climb
+  refill Checkpoint
+  refill Health=1:
+    moki:
+      Grapple OR Launch
+      Bash, Grenade=1  # wasted energy...
+    gorlek:
+      DoubleJump, TripleJump OR Dash
+      SentryJump=1
+    unsafe:
+      DoubleJump, Sword OR Hammer
+      Dash, Hammer
+  refill Energy=4:
+    moki:
+      DoubleJump, Grapple
+      DoubleJump, Bash, Grenade=1  # wasted energy...
+      Dash, Damage=20, Grapple
+      Dash, Damage=20, Bash, Grenade=1  # wasted energy...
+      Launch
+    gorlek:
+      Grapple, Dash OR Glide OR Sword
+      SentryJump=1
+      Bash, Grenade=1, Dash OR Glide OR Sword
+      DoubleJump, TripleJump OR Dash
+     unsafe:
+      DoubleJump, Sword OR Hammer OR Damage=20
+      Dash, Hammer
+
+  conn LowerReach.SnowEscape:
+    moki:
+      Bash, Grenade=5, Glide, DoubleJump
+      Bash, Grenade=4, Glide, Grapple
+      Bash, Glide, Launch
+    gorlek:
+      Launch, Bash OR SentryJump=1 OR Damage=20
+      Bash, SentryJump=3, Glide
+      Bash, SentryJump=3, DoubleJump, Dash OR TripleJump # SentryJump to get on the right wall at the 1st wind column. Use weapon to air stall as well to reach the 2nd one.
+      Bash, SentryJump=3, Grapple, DoubleJump OR Dash # SentryJump to get on the right wall at the 1st wind column
+      Bash, SentryJump=4, Grapple
+      Bash, Grenade=3, Glide
+      Bash, Grenade=4, Grapple
+      Bash, Grenade=3, DoubleJump, Grapple
+    unsafe:
+      Bash, DoubleJump, TripleJump, Damage=20
+      Bash, SentryJump=3, Sword, DoubleJump OR Dash OR Grapple
+      Bash, SentryJump=1, Glide
+      Bash, Grenade=3, Dash, Sword OR Hammer OR Flash=2 OR Sentry=2
+      Bash, Grenade=3, DoubleJump, TripleJump OR Dash OR Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
+  # backwards path can't get through the arena ceiling
+
+# checkpoint at 80, -3805
+
+anchor LowerReach.SnowEscape at 79, -3733:
+  refill Full
+
+  quest LowerReach.ForestsMemory:  # currently based on the requirements of getting here to simplify
+    moki, LowerReach.ArenaBeaten:
+      Dash, Bash, Grapple, Glide, Water OR DoubleJump
+      Bash, Glide, Launch
+    gorlek, LowerReach.ArenaBeaten:
+      Launch, Water OR Glide OR Damage=20
+      Dash, Glide, DoubleJump, TripleJump OR Damage=20
+      Dash, Glide, Grapple
+    unsafe, LowerReach.ArenaBeaten:
+      Dash, Glide, Damage=20
+      DoubleJump, Dash, TripleJump  # Require a blind wall jump, hard to do without debug renderer
+      SentryJump=1, DoubleJump, Dash, TripleJump  # Same path than above but the sjump ease it
+      SentryJump=2, DoubleJump, Dash  # 1st sjump on a friendly spike and 2nd one on the branch to pass the 1st wind column
+      SentryJump=3, Dash, Grapple OR Damage=20
+      Dash, SentryJump=4
+
+  pickup LowerReach.EscapeRevisitEX:
+    moki: LowerReach.ForestsMemory
+
+anchor LowerReach.TownEntry at -35, -4077:  # Where the wind starts
+  conn GladesTown.ReachPath: free
+  conn LowerReach.Trial:
+    moki:
+      Glide
+    gorlek:
+      Launch, DoubleJump, Damage=20
+      Launch, Bash, Grenade=1
+    unsafe:
+      Launch, DoubleJump, Dash OR TripleJump
+      Launch, Damage=20  # Launch on the wall at the start of the wind cave
+anchor LowerReach.Trial at 64, -4046:  # At trial start
+  refill Checkpoint
+
+  state LowerReach.KeystoneDoor:
+    moki: Keystone=4
+  # state LowerReach.TrialActivation:
+  #   moki: LowerReach.KeystoneDoor
+  state LowerReach.BearSneezed:
+    moki: LowerReach.ForestsMemory  # the game forces Baur awake when collecting the wisp
+
+  pickup LowerReach.RightKS:
+    moki:
+      Glide
+      DoubleJump, Dash, Bash, Grenade=1
+      Launch, DoubleJump OR Damage=20
+    gorlek:
+      Launch
+      SentryJump=1, DoubleJump
+      Bash, Grenade=1, DoubleJump
+  pickup LowerReach.UpperLeftKS:
+    moki: Glide
+    unsafe: Launch, DoubleJump, TripleJump, Damage=20  # Launch against the walls. When on the wall above GladesTown.ReachPath, first use triple jump then lauch, triple jump again to take a damage boost to refresh launch then launch and triple jump again to take the pickup and tp out
+  pickup LowerReach.MiddleLeftKS:
+    moki: Glide
+    unsafe: Launch, Damage=20, DoubleJump OR Dash  # Launch against the walls. When on the wall above GladesTown.ReachPath, first use djump/dash then lauch, reuse your mobility option, take a damage boost to refresh launch, take the pickup and TP out
+  pickup LowerReach.BottomLeftKS:
+    moki: Glide
+    unsafe:
+      Launch, Sword OR DoubleJump OR Dash OR Hammer OR Damage=20  # TP out after taking the pickup
+      DoubleJump, TripleJump, Damage=20 OR Sword OR Dash OR Hammer  # Start jumping from the highest point of the second platform, on the right. TP out after taking the pickup
+      Launch, Shuriken=1  # TP out after taking the pickup
+      DoubleJump, TripleJump, Shuriken=1  # Start jumping from the highest point of the second platform, on the right. TP out after taking the pickup
+  pickup LowerReach.TrialEX:
+    moki: Glide
+    unsafe: Launch, Damage=20, DoubleJump OR Dash  # Take a damage to refresh Launch/djump in the hiden area then tp out
+
+  conn LowerReach.TownEntry:
+    moki: Glide
+    gorlek:
+      Damage=20, Sword OR Dash OR DoubleJump OR Launch  # sword or hammer for weapon stalling
+      Bash, Grenade=1, Sword OR Dash OR DoubleJump OR Launch
+      Launch, Sword OR Hammer OR Dash OR DoubleJump
+      DoubleJump, Sword OR Hammer OR Dash OR TripleJump
+      Dash, Sword OR Hammer
+      SentryJump=1, Sword 
+    unsafe:
+      Bash, Grenade=1, Hammer
+      Damage=20, Hammer
+      Damage=50
+      Bash, Grenade=1, Damage=30
 
 region UpperReach:
   moki: Danger=40, Regenerate
@@ -4421,467 +4981,6 @@ anchor UpperReach.TreeRoom at -107, -3933:  # At the tree
       DoubleJump, TripleJump, Bash, Grenade=1
       Launch, Bash, Grenade=1
   # backwards connection can't get through the Icefall
-
-anchor LowerReach.SecondSoup at -316, -4037:  # Next to the soup below the teleporter
-  state LowerReach.CentralFurnace:
-    moki:
-      Combat=ShieldMiner, DoubleJump, Dash, Bash, Flap
-      Grenade=1, Combat=ShieldMiner OR Bash OR Burrow OR Launch
-    gorlek:
-      Bash, Flap, Combat=ShieldMiner OR Dash OR Launch
-      Grenade=1, DoubleJump OR Dash OR Glide
-
-  pickup LowerReach.MeltIceEX:
-    moki: Grenade=1
-    gorlek:
-      Bash, Flap
-      Sentry
-  pickup LowerReach.BurrowEX:
-    moki: Burrow, DoubleJump OR Dash OR Glide OR Launch
-    gorlek: Burrow  # Need to TP out to avoid falling into spikes. Sword OR Hammer OR Damage=20 OR Shuriken=1 to airstall otherwise
-
-  conn LowerReach.Central:
-    moki:
-      DoubleJump, Bash, Flap OR Grenade=1
-      DoubleJump, Burrow
-      Launch
-    gorlek:
-      DoubleJump  # Need to jump from the highest point on the cauldron when it's at his highest point (can just jump on the spot to make the cauldron reach that point)
-      Bash, Grenade=1 OR Flap  # With flap, need to juggle the projectile
-      SentryJump=1
-  conn LowerReach.WindChannel:
-    moki:
-      Combat=ShieldMiner OR Bash OR Launch
-      Burrow, DoubleJump OR Dash OR Glide
-
-anchor LowerReach.WindChannel at -256, -4035:  # The furnace left of the wind channel connecting to east reach
-  refill Checkpoint
-  refill Energy=3:
-    moki, Weapon:
-      Combat=ShieldMiner, DoubleJump OR Dash
-      Bash OR Launch
-    gorlek: Weapon
-
-  state LowerReach.CentralFurnace:
-    moki: Grenade=1
-
-  pickup LowerReach.BelowLupoEX:
-    moki:
-      DoubleJump, Bash, Grenade=1
-      Launch
-      LowerReach.CentralFurnace, DoubleJump OR Dash
-    gorlek:
-      SentryJump=1  # sjump from the frozen plant then upslash
-      Grenade=1, Bash, Damage=20 OR DoubleJump OR Dash OR Sword OR Glide
-      Flap, Bash, Damage=20 OR DoubleJump OR Dash OR Sword OR Glide
-      LowerReach.CentralFurnace, Glide OR Sword OR Hammer OR Damage=20
-  pickup LowerReach.BreakWallEX:
-    moki, BreakWall=20:
-      Combat=ShieldMiner OR Bash OR Launch
-      DoubleJump, Dash OR Glide
-  pickup LowerReach.WindBottomEX:
-    moki: Grenade=1, Glide  # grenade to light the lantern
-    gorlek:
-      Grenade=1, Damage=20 OR Glide  # Pickup too close from the spikes for a TP out
-      glitch:  # Sentry to light the lantern
-        Sentry=1, Glide, Launch OR SentryJump=1
-        Sentry=1, Damage=20, Launch OR SentryJump=1
-        Sentry=1, Glide, DoubleJump, TripleJump OR Hammer  # jump bellow the lantern, don't need any wall jump
-        Sentry=1, Damage=20, DoubleJump, TripleJump OR Hammer  # jump bellow the lantern, don't need any wall jump
-    unsafe:
-      Sentry=1, DoubleJump  # djump + sentry to light the lantern. The sentry need to explode when the butterfly is high (rng based?)
-  pickup LowerReach.WindHiddenEX:
-    moki: Grenade=1, Glide  # grenade to light the lantern
-    gorlek:
-      glitch:  # sentry to light the lantern
-        DoubleJump, Sentry=1, Glide, TripleJump OR Hammer
-        SentryJump=1, Sentry=1, Glide
-      Launch, DoubleJump OR Dash OR Sword
-    unsafe:
-      DoubleJump, TripleJump, Damage=20, Sword OR Hammer OR Bash  # tjump + upslash/bash the gorlek to climb the right wall, tjump to the left spiky wall, iframe to wjump and tjump again to wjump from the wall just above and tjump again to the ice wall<
-      SentryJump=2, Damage=20, DoubleJump OR Dash  # sjump, damage boost (the spikes wond t hit Ori after landing on them), sjump again then upsalsh to reach the right wall then sword combo to reach the pickup and tp out
-      DoubleJump, TripleJump, SentryJump=1, Damage=20  # same as above, triple jump + up slash to get to the right wall then jump into the spikes to avoid the first sjump
-
-  conn LowerReach.SecondSoup:
-    moki:
-      Combat=ShieldMiner, DoubleJump OR Dash OR Glide
-      Bash, Grenade=1
-      Launch
-    # gorlek: ShieldEnemyObstacle  @Validator: ShieldEnemyObstacle obsolete, should be Combat probably
-  conn LowerReach.SoupMoki:
-    moki: Grenade=1, Glide  # grenade to light the lantern
-    gorlek:
-      Launch, DoubleJump OR Dash OR Sword OR Hammer OR Damage=20
-      glitch:  # Sentry to light the lantern
-        DoubleJump, Sentry=1, Glide, TripleJump OR Hammer
-        SentryJump=1, Sentry=1, Glide
-    unsafe: Launch  # Might be gorlek
-
-# checkpoint at -223, -4043
-
-anchor LowerReach.SoupMoki at -240, -3989:  # Below the reach teleporter, where you hand delicious marshclam soup to a moki (or alternatively extuingish his fireplace...)
-  refill Energy=4:
-    moki: Weapon
-
-  quest LowerReach.HandToHandHat:
-    moki: GladesTown.HandToHandSoup
-
-  pickup LowerReach.WindHiddenEX:
-    moki:
-      DoubleJump, Dash, Glide
-      Launch, Glide
-    gorlek: DoubleJump OR Dash OR Glide OR Launch OR Sword OR Damage=20
-    unsafe:
-      Bash, Grenade=1
-      Flash=1 OR Sentry=1 OR Shuriken=1
-
-  conn LowerReach.WindChannel:
-    moki: Glide
-    gorlek: DoubleJump OR Dash OR Launch OR Sword OR Hammer OR Damage=20  # Can use Shuriken, Flash, Bow, Spike, Sentry to slow you down so you can avoid taking a damage (gorlek?)
-    unsafe: free
-  conn LowerReach.East:
-    moki:
-      DoubleJump, Dash, Bash, Grenade=2
-      Launch
-      gorlek:
-        Bash, Grenade=2
-        SentryJump=2
-      unsafe:
-        DoubleJump, TripleJump, Dash OR Sword  # climb the wall near the moki, dash then triple jump to the wall to reset your jumps and dash + triple jump to reach the plant. With sword, pogo the fire, triple jump + upslash to reach the wall to reset your jumps then sword jump to the plant
-
-anchor LowerReach.East at -182, -3968:  # Right of the Lantern opening the Tp room
-  refill Checkpoint
-  refill Full:  # use the teleporter
-    moki: Bash, Grenade=2, DoubleJump OR Dash OR Glide OR Launch
-    gorlek:
-      Bash, Grenade=2
-      # Grenade=1, DoubleJump, OR Dash OR Glide OR Launch OR Sword OR Hammer  not sure which was the intent xD
-      glitch:
-        Sentry=1, Launch OR SentryJump=1
-        Sentry=1, DoubleJump, TripleJump OR Hammer
-    unsafe:
-      Grenade=1, Sentry=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Spear=1
-  # could be considered moving this anchor to the left, closer to the teleporter, if it gets important on higher difficulties
-
-  state LowerReach.RolledSnowball:
-    moki: Grenade=1, Combat=Mantis OR Bash
-    gorlek, glitch:  # Sentry to melt the ice
-      Launch, Sentry=1
-      Damage=20, SentryJump=1, Sentry=1  # Jump in the spikes (won't damage Ori afterwards), sjump then sentry to melt the ice + sword combo to return to safety
-      DoubleJump, TripleJump, Sentry=1, Dash OR Glide OR Sword OR Hammer OR Damage=20  # Jump from the branch above the ice, triple jump to get close enough, sentry to melt the ice then return to safety
-    unsafe:
-      DoubleJump, TripleJump, Sentry=1, Shuriken=1 OR Blaze=1
-      DoubleJump, TripleJump, Sentry=2  # Same path as above but use one sentry to stall in the air and another one to melt the ice
-
-  pickup LowerReach.SnowballHC:
-    moki: LowerReach.RolledSnowball, Burrow, DoubleJump OR Dash OR Glide OR Launch OR Damage=20
-    gorlek: LowerReach.RolledSnowball, Burrow  # Dash in the snow before exiting the burrow section to get momentum
-
-  conn LowerReach.Teleporter:
-    moki:
-      Grenade=1, DoubleJump OR Dash OR Glide OR Launch
-      Bash, Grenade=2
-    gorlek:
-      Bash, Grenade=2
-      # Grenade=1, DoubleJump, OR Dash OR Glide OR Launch OR Sword OR Hammer  not sure which one was the intent :p
-      glitch:
-        Sentry=1, Launch OR SentryJump=1
-        Sentry=1, DoubleJump, TripleJump OR Hammer
-    unsafe:
-      Grenade=1, Sentry=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Spear=1
-  conn LowerReach.SoupMoki: free
-  conn LowerReach.PastSnowball:
-    moki, LowerReach.RolledSnowball:
-      DoubleJump OR Glide OR Launch
-      Bash, Grenade=1, Dash
-      Bash, Grenade=2
-    gorlek, LowerReach.RolledSnowball: Sword OR Hammer OR Bash OR Damage=20  # Bash the running ennemy to avoid the damage boost
-    unsafe, LowerReach.RolledSnowball: Grenade=1 OR Sentry=1 OR Shuriken=1 OR Flash=1 OR Blaze=1 OR Spear=1
-
-anchor LowerReach.PastSnowball at -99, -3982:  # At the bashnade pedestal after rolling the snowball
-  refill Checkpoint
-  refill Energy=4:  # fast respawning crystal
-    moki: Weapon
-
-  state LowerReach.EastDoorLantern:
-    moki:
-      Bash, Grenade=2, DoubleJump, Dash, Glide
-      Grenade=1, Launch
-    gorlek:
-      glitch:  # Sentry to light the lantern
-        Sentry=1, Launch
-        Glide, SentryJump=3, Sentry=1  # Same as above but one more sjump to get close enough to the lantern to light it with a sentry
-        Dash, SentryJump=3, Sentry=1
-        SentryJump=5, Sentry=1
-        SentryJump=1, DoubleJump, Sentry=1
-      Glide, SentryJump=2, Grenade=1  # Need to use up slashes (sword not mention because of the sjumps in the rest of the path)
-      Dash, SentryJump=2, Grenade=1
-      SentryJump=1, DoubleJump, Grenade=1
-      SentryJump=4, Grenade=1
-      Bash, Grenade=5, Damage=20
-      Bash, Grenade=2, DoubleJump, TripleJump OR Dash OR Glide OR Sword OR Hammer
-      Bash, Grenade=3, DoubleJump
-      Bash, Grenade=4, Dash OR Sword
-      Bash, Grenade=5, Glide OR Hammer
-    unsafe:
-      DoubleJump, TripleJump, Sentry=1 OR Grenade=1  # Need to get a really precise wall jump to get to the plants
-
-  pickup LowerReach.RoofLeftEX:
-    moki:
-      LowerReach.CoolEastFurnace, Bash, Grenade=2, DoubleJump, Dash, Glide  # blame moon
-      Launch, DoubleJump, Dash OR Glide
-      Bash, Grenade=1, Launch
-    gorlek:
-      Launch, DoubleJump OR Dash OR Glide OR Sword OR Hammer  # Launch on the ceiling, use your mobility option then launch again
-      Bash, Grenade=2, DoubleJump, TripleJump OR Dash OR Glide  # the triple jump one needs a pretty precise angle for the second bash grenade, might move it to unsafe
-      SentryJump=1, DoubleJump, TripleJump
-    unsafe:
-      SentryJump=1, DoubleJump, Dash
-      Launch, Shuriken=2 OR Sentry=2  # Launch on the ceiling, sentry/shuriken -> launch -> sentry/shuriken again
-  pickup LowerReach.RoofRightEX:
-    moki:
-      LowerReach.CoolEastFurnace, Bash, Grenade=2
-      Launch
-    gorlek:
-      SentryJump=2
-      Bash, Grenade=2
-      Bash, Grenade=1, DoubleJump, Dash OR Sword  # Climb on the right wall above the 2nd plant
-      SentryJump=1, DoubleJump  # Climb on the wall above the 2nd plant
-    unsafe:
-      DoubleJump, TripleJump  # Need to get a really precise wall jump to get to the plants
-
-  conn LowerReach.SwimmingPool:
-    moki:
-      Bash, Grenade=1, DoubleJump, Dash, Glide
-      Launch
-    gorlek:
-      SentryJump=1, DoubleJump OR Dash OR Glide  # Need to use some upslashes with Glide
-      SentryJump=2
-      Bash, Grenade=1, DoubleJump, Damage=20 OR TripleJump OR Dash OR Glide OR Sword OR Hammer
-      Bash, Grenade=1, Sword
-      Bash, Grenade=2, Dash
-      Bash, Grenade=3, Glide
-    unsafe:
-      DoubleJump, TripleJump  # Need to get a really precise wall jump to get to the plants
-      Bash, Grenade=1, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR LowerReach.HeatEastFurnace  # Need to walljump on the wall above the 2nd plant then dash, get a reset by touching the ceilin and dash a second time
-    # shuriken break note: this wall has 20 health
-  # backwards path can't get past the snowball
-
-# checkpoint at -60, -3987
-
-anchor LowerReach.SwimmingPool at -44, -4001:  # At the platform in the freezable water
-  refill Energy=4:
-    moki: Weapon, LowerReach.CoolEastFurnace OR Water
-
-  state LowerReach.HeatEastFurnace:
-    moki:
-      Bash, Grenade=2
-      Grenade=1, Launch
-    gorlek:
-      DoubleJump, Grenade=1  # Climb the right wal then jump to the left wall before double jumping again to the platform
-      SentryJump=1, Grenade=1
-      LowerReach.HeatEastFurnace, WaterDash, Grenade=1, Water OR Damage=20  # Don't know if usefull since you need the state LowerReach.HeatEastFurnace to reach that same state
-    unsafe: Dash, Grenade=1  # Precise wall jump on the right wall then dash to the left, wall jump and dash again
-  state LowerReach.CoolEastFurnace:  # the intentional path is to cool this furnace
-    moki:
-      Flap, Bash, Grenade=1
-      Flap, Launch
-    gorlek:
-      DoubleJump, Flap  # Climb the right wal then jump to the left wall before double jumping again to the platform
-      SentryJump=1, Flap
-      LowerReach.HeatEastFurnace, WaterDash, Flap, Water OR Damage=20
-    unsafe: Dash, Flap  # Precise wall jump on the right wall then dash to the left, wall jump and dash again
-
-  pickup LowerReach.FractureShard:
-    moki: LowerReach.HeatEastFurnace, Water
-
-  conn LowerReach.ArenaArea:
-    moki, LowerReach.EastDoorLantern:
-      LowerReach.CoolEastFurnace, Bash, Grenade=1
-      Launch, LowerReach.CoolEastFurnace OR DoubleJump OR Dash OR Glide
-    gorlek, LowerReach.EastDoorLantern:
-      Launch  # Launch into the ceiling then into the wall near the energy cristal and again to the platform
-      SentryJump=1, LowerReach.CoolEastFurnaced OR Water
-      SentryJump=1, DoubleJump, TripleJump OR Dash OR Glide          # double jump from the platform, refill dash/jumps by slashing the energy cristal then sjump on the plant
-      SentryJump=2, DoubleJump OR Dash OR Glide
-      Bash, Grenade=1, Water
-      Bash, Grenade=1, Damage=20, DoubleJump OR Dash
-      Bash, Grenade=1, Damage=20, WaterDash, Glide OR Sword  # Jump, air stall, damage boost to waterdash and air stall again
-      Bash, Grenade=1, DoubleJump, Sword, TripleJump OR Dash OR Glide
-      Bash, Grenade=2, Damage=20 OR Dash OR Glide
-      Bash, Grenade=2, Sword, DoubleJump OR Dash
-      Bash, Grenade=2, Hammer, DoubleJump OR Dash
-      LowerReach.HeatEastFurnace:
-        WaterDash, Water, DoubleJump  # Wall jump from the right wall
-        WaterDash, Water, Hammer  # Wall jump from the right wall
-        DoubleJump, TripleJump, Sword  # bait the plant, triple jump + up slash on the right wall
-        DoubleJump, TripleJump, Hammer, Water OR Damage=20  # bait the plant, triple jump + up slash on the right wall
-  conn LowerReach.PastSnowball:
-    moki, BreakWall=20:
-      Bash, Grenade=1
-      Launch
-    gorlek, BreakWall=20:
-      DoubleJump OR SentryJump=1
-      LowerReach.HeatEastFurnace, WaterDash, Water OR Damage=20
-    unsafe: Dash, BreakWall=20  # Precise wall jump on the right wall then dash to the left, wall jump and dash again
-
-anchor LowerReach.ArenaArea at 44, -3992:  # To the left of the combat arena
-  refill Checkpoint
-  refill Health=1
-  refill Energy=3:
-    moki:
-      Weapon, DoubleJump, Dash
-      Weapon, Launch
-      Bow=1 OR Spear=1 OR Grenade=1
-
-  state LowerReach.ArenaBeaten:
-    moki: Regenerate, Damage=40, Combat=3xShieldMiner+Hornbug+2xBee
-    unsafe: Combat=3xShieldMiner+Hornbug+2xBee
-
-  conn LowerReach.Trial:
-    moki: LowerReach.ArenaBeaten
-  conn LowerReach.WispPath:
-    moki, LowerReach.ArenaBeaten:
-      Glide, Grapple OR Launch
-      Glide, DoubleJump, Bash, Grenade=1
-    gorlek, LowerReach.ArenaBeaten:
-      Glide, SentryJump=1
-      Glide, Bash, Grenade=1
-      Glide, DoubleJump, TripleJump OR Sword OR Hammer OR Dash OR Damage=20  # With dboost, jump in the spike wall then djump
-      Glide, Dash, Hammer
-      Launch, DoubleJump OR Dash OR Sword OR Damage=20  # Pass the 3 first spinner, wall jump on the right wall, stall, launch into the ceiling, relaunch on the left wall
-    unsafe, LowerReach.ArenaBeaten:
-      Launch, Shuriken=1 OR Sentry=1 OR Spear=1 OR Flash=1  # Pass the 3 first spinner, wall jump on the right wall, stall, launch into the ceiling, relaunch on the left wall
-      DoubleJump, TripleJump, Damage=20, Dash OR Sword OR Hammer OR Shuriken=2 OR Sentry=2 OR Flash=2 OR Blaze=2 OR Spear=2  # Climb the right wall, triple jump + stall to the left wall, return to the right before the 2nd spinner, climb  the left wall after the 3rd spinner, stall as much possible in the air, take a damage boost on the spike floor then go to the right wall. You can saty on the right wall and climb to the energy cristal with triple jump
-      Bash, Grenade=2, DoubleJump, TripleJump, Damage=20  # Same as above. 1st bash grenade to access directly to the left wall in the arena and second one just after the 3rd spinner
-  # backwards path can't get through the door
-
-# checkpoint at just kidding, placed this mark because the refill logic below kind of sucks
-
-anchor LowerReach.WispPath at 83, -3874:  # Halfway through the climb
-  refill Checkpoint
-  refill Health=1:
-    moki:
-      Grapple OR Launch
-      Bash, Grenade=1  # wasted energy...
-    gorlek:
-      DoubleJump, TripleJump OR Dash OR Sword OR Hammer
-      Dash, Hammer
-      SentryJump=1
-  refill Energy=4:
-    moki:
-      DoubleJump, Grapple
-      DoubleJump, Bash, Grenade=1  # wasted energy...
-      Dash, Damage=20, Grapple
-      Dash, Damage=20, Bash, Grenade=1  # wasted energy...
-      Launch
-    gorlek:
-      Grapple, Dash OR Glide OR Sword
-      SentryJump=1
-      Bash, Grenade=1, Dash OR Glide OR Sword
-      DoubleJump, TripleJump OR Dash OR Sword OR Hammer OR Damage=20
-      Dash, Hammer
-
-  conn LowerReach.SnowEscape:
-    moki:
-      Bash, Grenade=5, Glide, DoubleJump
-      Bash, Grenade=4, Glide, Grapple
-      Bash, Glide, Launch
-    gorlek:
-      Launch, Bash OR SentryJump=1 OR Damage=20
-      Bash, SentryJump=2, Glide
-      Bash, SentryJump=3, DoubleJump OR Dash OR Grapple  # SentryJump + upslash to get on the right wall at the 1st wind column
-      Bash, DoubleJump, TripleJump, Damage=20
-      Bash, Grenade=2, Glide
-      Bash, Grenade=3, Grapple  # At the last grapple, need to wall jump on the trunk just above, can be hard. If too hard for gorlek, add a bash grenade in order to reach the top
-      Bash, Grenade=3, DoubleJump, TripleJump OR Dash OR Grapple OR Sword OR Hammer
-      Bash, Grenade=3, Dash, Sword OR Hammer  # Up Slash with hammer to a little higher on the left wall at the 1st wind column. Same with sentry (+one to stall in the air), might moove to unsafe
-    unsafe:
-      Bash, Grenade=3, Dash, Sword OR Hammer OR Flash=2 OR Sentry=2
-      Bash, Grenade=3, DoubleJump, Shuriken=1 OR Flash=1 OR Sentry=1
-  # backwards path can't get through the arena ceiling
-
-# checkpoint at 80, -3805
-
-anchor LowerReach.SnowEscape at 79, -3733:
-  refill Full
-
-  quest LowerReach.ForestsMemory:  # currently based on the requirements of getting here to simplify
-    moki, LowerReach.ArenaBeaten:
-      Dash, Bash, Grapple, Glide, Water OR DoubleJump
-      Bash, Glide, Launch
-    gorlek, LowerReach.ArenaBeaten:
-      Launch
-      Dash, Glide, DoubleJump OR Grapple OR Damage=20
-    unsafe, LowerReach.ArenaBeaten:
-      DoubleJump, Dash, TripleJump  # Require a blind wall jump, hard to do without debug renderer
-      SentryJump=1, DoubleJump, Dash, TripleJump  # Same path than above but the sjump ease it
-      SentryJump=2, DoubleJump, Dash  # 1st sjump on a friendly spike and 2nd one on the branch to pass the 1st wind column
-      SentryJump=3, Dash, Grapple OR Damage=20
-      Dash, SentryJump=4
-
-  pickup LowerReach.EscapeRevisitEX:
-    moki: LowerReach.ForestsMemory
-
-anchor LowerReach.TownEntry at -35, -4077:  # Where the wind starts
-  conn GladesTown.ReachPath: free
-  conn LowerReach.Trial:
-    moki:
-      Glide
-    gorlek:
-      Launch, Damage=20  # Launch on the wall at the start of the wind cave
-      Launch, DoubleJump, Dash OR TripleJump
-      Launch, Bash, Grenade=1
-
-anchor LowerReach.Trial at 64, -4046:  # At trial start
-  refill Checkpoint
-
-  state LowerReach.KeystoneDoor:
-    moki: Keystone=4
-  # state LowerReach.TrialActivation:
-  #   moki: LowerReach.KeystoneDoor
-  state LowerReach.BearSneezed:
-    moki: LowerReach.ForestsMemory  # the game forces Baur awake when collecting the wisp
-
-  pickup LowerReach.RightKS:
-    moki:
-      Glide
-      DoubleJump, Dash, Bash, Grenade=1
-      Launch, DoubleJump OR Damage=20
-    gorlek:
-      Launch
-      SentryJump=1, DoubleJump
-      Bash, Grenade=1, DoubleJump
-  pickup LowerReach.UpperLeftKS:
-    moki: Glide
-    gorlek: Launch, DoubleJump, TripleJump, Damage=20  # Launch against the walls. When on the wall above GladesTown.ReachPath, first use triple jump then lauch, triple jump again to take a damage boost to refresh launch then launch and triple jump again to take the pickup and tp out
-  pickup LowerReach.MiddleLeftKS:
-    moki: Glide
-    gorlek: Launch, Damage=20, DoubleJump OR Dash  # Launch against the walls. When on the wall above GladesTown.ReachPath, first use djump/dash then lauch, reuse your mobility option, take a damage boost to refresh launch, take the pickup and TP out
-  pickup LowerReach.BottomLeftKS:
-    moki: Glide
-    gorlek:
-      Launch, Sword OR DoubleJump OR Dash OR Hammer OR Damage=20  # TP out after taking the pickup
-      DoubleJump, TripleJump, Damage=20 OR Sword OR Dash OR Hammer  # Start jumping from the highest point of the second platform, on the right. TP out after taking the pickup
-    unsafe:
-      Launch, Shuriken=1  # TP out after taking the pickup
-      DoubleJump, TripleJump, Shuriken=1  # Start jumping from the highest point of the second platform, on the right. TP out after taking the pickup
-  pickup LowerReach.TrialEX:
-    moki: Glide
-    gorlek: Launch, Damage=20, DoubleJump OR Dash  # Take a damage to refresh Launch/djump in the hiden area then tp out
-
-  conn LowerReach.TownEntry:
-    moki: Glide
-    gorlek:
-      Damage=20, Sword OR Hammer OR Dash OR DoubleJump OR Launch  # sword or hammer for weapon stalling
-      Bash, Grenade=1, Sword OR Hammer OR Dash OR DoubleJump OR Launch
-      Launch, Sword OR Hammer OR Dash OR DoubleJump
-      DoubleJump, Sword OR Hammer OR Dash OR TripleJump
-      Dash, Sword OR Hammer
-      SentryJump=1
-    unsafe:
-      Damage=50
-      Bash, Grenade=1, Damage=30
 
 region UpperDepths:
   moki: Danger=40, Regenerate


### PR DESCRIPTION
Nerfed LowerReach, added back some unsafe paths that we wrote with Lusther which were lost after the merge, fixed some logic issues (mainly added Sword/Hammer as a requirement for weapon air stalling and fixed some Sentry Jump paths)